### PR TITLE
govorilne ure četrtek - samo v živo

### DIFF
--- a/notebooks/Študijski in izpitni red.ipynb
+++ b/notebooks/Študijski in izpitni red.ipynb
@@ -57,7 +57,7 @@
     "\n",
     "**Govorilne ure:**\n",
     "* **torek 13:00 - 13:30** (as. Klemen zaletelj) (samo online - [povezava](https://uni-lj-si.zoom.us/j/97856662332?pwd=RStsbEYvTC81WWFSTnpWeHNJZDBjQT09))\n",
-    "* **četrtek 11:30 - 12:00** (as. Domen Gorjup) (online - [povezava](https://uni-lj-si.zoom.us/j/97710778532?pwd=alYzclphck1wOTV4dSs5dUo1NCs4Zz09) in v učilnici **II/1**)\n",
+    "* **četrtek 11:30 - 12:00** (as. Domen Gorjup) (samo v učilnici **II/1**)\n",
     "\n",
     "\n",
     "**Asistenti:**\n",
@@ -404,7 +404,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.1"
   },
   "latex_envs": {
    "bibliofile": "biblio.bib",


### PR DESCRIPTION
Četrtkove govorilne ure potekajo le v živo (termin govorilnih ur preko Zooma je v torek).